### PR TITLE
Improve FortiNBI process management

### DIFF
--- a/test_runner.py
+++ b/test_runner.py
@@ -11,8 +11,9 @@ if __name__ == '__main__':
     print("SSH Output:", output)
 
     # Check if a process is running and start it if not
+    proc = None
     if not FortiNBIManager.is_process_running('FortiNBI.exe'):
-        FortiNBIManager.start_process(r'C:\Program Files (x86)\Fortinet\FortiNBI\FortiNBI.exe')
+        proc = FortiNBIManager.start_process(r'C:\Program Files (x86)\Fortinet\FortiNBI\FortiNBI.exe')
 
     # Create test suite
     suite = unittest.TestSuite()
@@ -23,3 +24,6 @@ if __name__ == '__main__':
 
     # Run the test suite
     unittest.TextTestRunner().run(suite)
+
+    if proc:
+        FortiNBIManager.stop_process(proc)


### PR DESCRIPTION
## Summary
- return `Popen` from `start_process` and wait for the process
- add `stop_process` to terminate an existing FortiNBI instance
- use the new methods in `test_runner`

## Testing
- `pip install -r requirements.txt` *(fails: No matching distribution found for pywin32)*
- `pytest -q` *(fails: ModuleNotFoundError: No module named 'psutil')*

------
https://chatgpt.com/codex/tasks/task_e_68426ef68a3c833093a3ff58eeb6bbe5