### PR TITLE
Fix setup config for packages and README

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -1,9 +1,13 @@
 from setuptools import find_packages, setup
 
+with open("README.md", encoding="utf-8") as fh:
+    long_description = fh.read()
+
 setup(
     name="fnbi-automated-testing",
     version="0.1",
-    packages=find_packages(),
+    packages=find_packages(where="src"),
+    package_dir={"": "src"},
     install_requires=[
         "pytest",
         "selenium",
@@ -21,7 +25,7 @@ setup(
     author="Your Name",
     author_email="your.email@example.com",
     description="Automated testing suite for FortiNBI application",
-    long_description=open("README.md").read(),
+    long_description=long_description,
     long_description_content_type="text/markdown",
     url="https://github.com/yourusername/fnbi-automated-testing",
     classifiers=[


### PR DESCRIPTION
## Summary
- ensure README is read using utf-8 encoding
- set packages to be discovered from `src`
- set package_dir for src layout

## Testing
- `pytest -q` *(fails: ModuleNotFoundError: No module named 'faiss')*

------
https://chatgpt.com/codex/tasks/task_e_684283a2f3608330bdb8254b5586ffd1