### PR TITLE
Fix missing time import

### DIFF
--- a/FortiNBIManager.py
+++ b/FortiNBIManager.py
@@ -1,6 +1,7 @@
 import subprocess
 
 import psutil
+import time
 
 from src.utils import read_config
 import os


### PR DESCRIPTION
## Summary
- fix missing import of `time` used by `FortiNBIManager.start_process`

## Testing
- `pytest -q` *(fails: ModuleNotFoundError: No module named 'faiss')*

------
https://chatgpt.com/codex/tasks/task_e_684283a7def48330a6c28eca517e2d62