### PR TITLE
Fix CI workflow

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -17,10 +17,13 @@ jobs:
       - name: Install dependencies
         run: |
           python -m pip install --upgrade pip
-          pip install -r requirements.txt || true
+          pip install -r requirements.txt
+          pip install pre-commit
+      - name: Run pre-commit
+        run: pre-commit run --show-diff-on-failure --color=always --all-files
       - name: Run tests
         run: |
-          pytest -vv || true
+          pytest -vv
       - name: Upload artifacts
         if: always()
         uses: actions/upload-artifact@v3


### PR DESCRIPTION
## Summary
- run `pre-commit` before `pytest`
- remove `|| true` from install and test steps

## Testing
- `pytest -q` *(fails: ModuleNotFoundError: No module named 'faiss')*

------
https://chatgpt.com/codex/tasks/task_e_684283b604ec83309fa55a4571a595e2