### PR TITLE
Add functional test setup scripts

### DIFF
--- a/scripts/run_tests.sh
+++ b/scripts/run_tests.sh
@@ -1,1 +1,14 @@
+#!/usr/bin/env bash
+# Run the project's pytest suite using the Python helper script.
+set -euo pipefail
 
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+REPO_ROOT="$(cd "$SCRIPT_DIR/.." && pwd)"
+cd "$REPO_ROOT"
+
+# Activate the virtual environment if it exists
+if [ -f "venv/bin/activate" ]; then
+    source venv/bin/activate
+fi
+
+python "$SCRIPT_DIR/run_tests.py" "$@"

--- a/scripts/setup_environment.sh
+++ b/scripts/setup_environment.sh
@@ -1,1 +1,22 @@
+#!/usr/bin/env bash
+# Set up a Python virtual environment and install project dependencies.
+set -euo pipefail
 
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+REPO_ROOT="$(cd "$SCRIPT_DIR/.." && pwd)"
+cd "$REPO_ROOT"
+
+if [ ! -d "venv" ]; then
+    python3 -m venv venv
+fi
+
+source venv/bin/activate
+pip install --upgrade pip
+pip install -r requirements.txt
+pip install -e .
+
+if [ ! -f config/config.yaml ] && [ -f config/config.yaml.example ]; then
+    cp config/config.yaml.example config/config.yaml
+fi
+
+echo "Environment setup complete."


### PR DESCRIPTION
## Summary
- implement usable `run_tests.sh` and `setup_environment.sh`
- make scripts executable

## Testing
- `python scripts/run_tests.py` *(fails: ModuleNotFoundError: No module named 'faiss')*

------
https://chatgpt.com/codex/tasks/task_e_684283c26b20833083e79db9372eaa7a